### PR TITLE
wrong cross-arch numbers

### DIFF
--- a/shm_linux_arm.go
+++ b/shm_linux_arm.go
@@ -1,11 +1,15 @@
 package shm
 
+import (
+	"syscall"
+)
+
 // System call constants.
 const (
-	sysShmAt  = 21
-	sysShmCtl = 24
-	sysShmDt  = 22
-	sysShmGet = 23
+	sysShmAt  = syscall.SYS_SHMAT
+	sysShmCtl = syscall.SYS_SHMCTL
+	sysShmDt  = syscall.SYS_SHMDT
+	sysShmGet = syscall.SYS_SHMGET
 )
 
 // Perm is used to pass permission information to IPC operations.

--- a/shm_linux_arm64.go
+++ b/shm_linux_arm64.go
@@ -1,11 +1,15 @@
 package shm
 
+import (
+	"syscall"
+)
+
 // System call constants.
 const (
-	sysShmAt  = 21
-	sysShmCtl = 24
-	sysShmDt  = 22
-	sysShmGet = 23
+	sysShmAt  = syscall.SYS_SHMAT
+	sysShmCtl = syscall.SYS_SHMCTL
+	sysShmDt  = syscall.SYS_SHMDT
+	sysShmGet = syscall.SYS_SHMGET
 )
 
 // Perm is used to pass permission information to IPC operations.


### PR DESCRIPTION
The syscall numbers for arm/arm64 architectures are not correct.
Using syscall.SYS_SHMGET instead works for me.
I am not sure, if the same works for linux_386 and freebsd, but there the numbers seem correct.

https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md#cross_arch-numbers